### PR TITLE
Draft of MPB cuFFTW support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,11 +123,16 @@ fi
 ##############################################################################
 AC_ARG_WITH(mpi, [AC_HELP_STRING([--with-mpi],[enable MPI parallelization])], with_mpi=$withval, with_mpi=no)
 AC_ARG_WITH(fftw2, [AC_HELP_STRING([--with-fftw2],[prefer FFTW2 to FFTW3])], with_fftw2=$withval, with_fftw2=no)
+AC_ARG_WITH(cufftw, [AC_HELP_STRING([--with-cufftw],[prefer cuFFTW to FFTW3])], with_cufftw=$withval, with_cufftw=no)
 
 # Check for FFTW libraries
 fftw3_func=execute
 test "x$with_fftw2" = xyes && fftw3_func=notarealfunction # prefer FFTW2
-if test "$enable_single" = "yes"; then
+test "x$with_cufftw" = xyes && fftw3_func=notarealfunction # prefer cuFFTW
+
+if test "x$with_cufftw" = xyes; then
+	AC_CHECK_LIB(cufftw, fftw_execute)
+elif test "$enable_single" = "yes"; then
         AC_CHECK_LIB(fftw3f, fftwf_$fftw3_func, [], [
 	AC_CHECK_LIB(sfftw, fftw)
 	if test x"$inv_sym" = xyes; then
@@ -154,13 +159,24 @@ if test x = x"`echo $LIBS | egrep 'l[[dsx]]fftw|fftw3'`"; then
 	fi
 fi
 
-if test x = x"`echo $LIBS | egrep 'l[[dsx]]*fftw'`"; then
-	AC_MSG_ERROR([The FFTW libraries could not be found.  Make sure FFTW is installed, and that LDFLAGS and CPPFLAGS are set appropriately if necessary.])
-fi
+echo "LIBS=$LIBS"
 
-if test x"$inv_sym" = xyes; then
-	if test x = x"`echo $LIBS | egrep 'l[[dsx]]*rfftw|lfftw3'`"; then
-		AC_MSG_ERROR([The FFTW3 or RFFTW libraries, which are required to compile MPB with inversion symmetry, could not be found.  These should have been installed as a part of FFTW.])
+if test "x$with_cufftw" = xyes; then
+	if test x = x"`echo $LIBS | egrep 'l[[dsx]]*cufft'`"; then
+		AC_MSG_ERROR([The cuFFT library could not be found.  Make sure cuFFT is installed, and that LDFLAGS and CPPFLAGS are set appropriately if necessary. Note that both -lcufft and -lcufftw must be specified.])
+	fi
+	if test x = x"`echo $LIBS | egrep 'l[[dsx]]*cufftw'`"; then
+		AC_MSG_ERROR([The cuFFTW library could not be found.  Make sure cuFFTW is installed, and that LDFLAGS and CPPFLAGS are set appropriately if necessary. Note that both -lcufft and -lcufftw must be specified.])
+	fi
+else
+	if test x = x"`echo $LIBS | egrep 'l[[dsx]]*fftw'`"; then
+		AC_MSG_ERROR([The FFTW libraries could not be found.  Make sure FFTW is installed, and that LDFLAGS and CPPFLAGS are set appropriately if necessary.])
+	fi
+
+	if test x"$inv_sym" = xyes; then
+		if test x = x"`echo $LIBS | egrep 'l[[dsx]]*rfftw|lfftw3'`"; then
+			AC_MSG_ERROR([The FFTW3 or RFFTW libraries, which are required to compile MPB with inversion symmetry, could not be found.  These should have been installed as a part of FFTW.])
+		fi
 	fi
 fi
 
@@ -169,6 +185,9 @@ fi
 
 AC_ARG_WITH(openmp, [AC_HELP_STRING([--with-openmp],[enable OpenMP parallelization])], with_omp=$withval, with_omp=no)
 if test "x$with_omp" = xyes; then
+	if test "x$with_cufftw" = "xyes"; then
+		AC_MSG_ERROR([cuFFTW and OpenMP cannot both be enabled.])
+	fi
    AC_DEFINE([USE_OPENMP], [1], [Define to use OpenMP threading.])
    AX_OPENMP([], [AC_MSG_ERROR([Could not find OpenMP flag; configure with --without-openmp])])
    CFLAGS="$CFLAGS $OPENMP_CFLAGS"
@@ -198,6 +217,9 @@ LIBS="$LAPACK_LIBS $BLAS_LIBS $LIBS $FLIBS"
 # Check for MPI library
 
 if test "x$with_mpi" = "xyes"; then
+	if test "x$with_cufftw" = "xyes"; then
+		AC_MSG_ERROR([cuFFTW and MPI cannot both be enabled.])
+	fi
 	AX_MPI([], [AC_MSG_ERROR(could not find mpi library for --with-mpi)])
         CC="$MPICC"
 	LIBS="$MPILIBS $LIBS"

--- a/src/maxwell/imaxwell.h
+++ b/src/maxwell/imaxwell.h
@@ -24,7 +24,10 @@
 
 #include "maxwell.h"
 
-#if defined(HAVE_LIBFFTW3) || defined(HAVE_LIBFFTW3F) || defined(HAVE_LIBFFTW3L)
+#if defined(HAVE_LIBCUFFTW)
+#  include <cufftw.h>
+#  define HAVE_FFTW3 1
+#elif defined(HAVE_LIBFFTW3) || defined(HAVE_LIBFFTW3F) || defined(HAVE_LIBFFTW3L)
 #  include <fftw3.h>
 #  ifdef HAVE_MPI
 #    include <fftw3-mpi.h>


### PR DESCRIPTION
This draft PR (intentionally targeted to my own fork for now) attempts to build MPB with cuFFTW for performing Fourier Transforms on NVIDIA CUDA GPUs. This PR exists to document some tests I did and the results. I am not sure if I will pursue this further at the moment but I hope this information will be helpful to my future self or another user of MPB who wishes to compute on a GPU.

I built libctl with `./autogen.sh --prefix=$HOME/libctl; sudo make install -j` and then built MPB with the command:

```bash
PATH="$PATH:$HOME/libctl/bin" \
CFLAGS="-I/usr/local/cuda/include" \
LDFLAGS="-L/usr/local/cuda/lib64" \
LIBS="-lcufft -lcufftw" \
./autogen.sh --with-cufftw --without-openmp

sudo make install -j
```

I ran this on Ubuntu 20.04 inside of WSL2 (configured with CUDA support).

In order to make this PR viable for inclusion in the upstream MPB code, it would need:
- [ ] Some analysis of the data access patterns, with an attempt to improve performance. I have done very little research into the internals of MPB while preparing this test code. See below for performance.
- [ ] Tests for correctness (compare results to the CPU-only code).
- [ ] Some cleanup of the build system modifications, especially in the parts that interact with OpenMP / MPI, to prevent users from requesting invalid combinations of options. Perhaps `-lcufft -lcufftw` should be automatically included in `LIBS` if the user enables `--with-cufftw`?

I was able to make the application run without crashing, but it is slower than the CPU-only version by a fair bit (maybe 5x?). I'm running an NVIDIA RTX 2070 Super GPU and a Ryzen 9 3900X CPU (12 cores). The MPB code is not yet optimized _at all_ for use with a GPU. It would be much better to keep data on the GPU rather than copy host-device in both directions for every FFT performed, and that might require a re-write of some portions of the MPB code. The smaller FFT sizes may not be large enough to make it worth the cost of copying data from host to device, if I were to guess (I have collected no data to support this claim thus far). This is a first pass and I strongly suspect the performance could be substantially improved. The [cuFFT docs](https://docs.nvidia.com/cuda/cufft/index.html) indicate many ways to get better performance, some of which specifically apply to the case of porting from FFTW to cuFFT(W).

I am also not sure if the results are correct (I saw several NaN values in the log where I expected finite values, but I haven't checked this closely -- just a brief glance as the log output was scrolling by).

It seems from a quick test that setting `--without-openmp` didn't work, because the application still ran on all my CPU cores, which may have also led to contention for host-device traffic if it's trying to run many FFTs concurrently on the GPU. I tried setting `OMP_NUM_THREADS=1` while running and it got slightly faster (but used fewer CPU cores). I do not know the threading model of MPB (haven't read the source yet) and it's possible that I'm way off base in my understanding of what MPB is executing on each thread, or perhaps I am not using the options properly.